### PR TITLE
Fixed issues for brew, script and updated README

### DIFF
--- a/Formula/sshkeymanager.rb
+++ b/Formula/sshkeymanager.rb
@@ -1,0 +1,52 @@
+# typed: false
+# frozen_string_literal: true
+
+class Sshkeymanager < Formula
+  desc "Manages SSH keys, agent, and loads keys for shell sessions"
+  homepage "https://github.com/ggthedev/SSHKEYSMANAGER"
+  url "https://github.com/ggthedev/SSHKEYSMANAGER/archive/refs/tags/v0.0.1.tar.gz"
+  sha256 "e5f9192a754c96f4b4192ccca0b156d3e9770664"
+  version "0.0.1"
+
+  head "https://github.com/ggthedev/SSHKEYSMANAGER.git", branch: "main"
+
+  depends_on "coreutils" # Provides 'date' with nanoseconds needed by the script
+
+  def install
+    # Install the main script to bin
+    bin.install "sshkeymanager.sh"
+    # Install the agent setup script to libexec as it's meant to be sourced
+    libexec.install "ssh_agent_setup.sh"
+  end
+
+  def caveats
+    <<~EOS
+      The main utility `sshkeymanager.sh` has been installed to:
+        #{opt_bin}/sshkeymanager.sh
+
+      To activate the SSH agent setup for your shell sessions, add the following
+      line to your shell profile (e.g., ~/.zshrc, ~/.bash_profile, ~/.profile):
+
+        source "#{opt_libexec}/ssh_agent_setup.sh"
+
+      Ensure you remove any previous manual sourcing of the agent script.
+
+      Configuration and logs are typically stored in:
+        ~/.config/sshkeymanager/
+        ~/Library/Logs/sshkeymanager/ (macOS) or ~/.local/log/sshkeymanager/ (Linux fallback)
+
+      Restart your shell or source your profile for changes to take effect.
+    EOS
+  end
+
+  test do
+    # Test syntax of the sourced script
+    system "bash", "-n", libexec/"ssh_agent_setup.sh"
+
+    # Test presence and basic execution of the main script
+    assert_predicate bin/"sshkeymanager.sh", :exist?
+    assert_predicate bin/"sshkeymanager.sh", :executable?
+    # Check if running with --help works (replace with a more meaningful basic command if needed)
+    shell_output("#{bin}/sshkeymanager.sh --help")
+  end
+end 

--- a/Formula/sshkeymanager.rb
+++ b/Formula/sshkeymanager.rb
@@ -4,23 +4,31 @@
 class Sshkeymanager < Formula
   desc "Manages SSH keys, agent, and loads keys for shell sessions"
   homepage "https://github.com/ggthedev/SSHKEYSMANAGER"
-  url "https://github.com/ggthedev/SSHKEYSMANAGER/archive/refs/tags/v0.0.1.tar.gz"
-  sha256 "e5f9192a754c96f4b4192ccca0b156d3e9770664"
+  url "https://github.com/ggthedev/SSHKEYSMANAGER/archive/refs/tags/0.0.1.tar.gz"
+  sha256 "6fa89fc75a733000f5804dd8d9bd8b83e291c9b3cd472ac65dad96030fe853d2"
   version "0.0.1"
 
   head "https://github.com/ggthedev/SSHKEYSMANAGER.git", branch: "main"
 
   depends_on "coreutils" # Provides 'date' with nanoseconds needed by the script
+  # Make gnu-getopt optional on macOS
+  depends_on "gnu-getopt" => :optional if OS.mac?
 
   def install
     # Install the main script to bin
     bin.install "sshkeymanager.sh"
     # Install the agent setup script to libexec as it's meant to be sourced
     libexec.install "ssh_agent_setup.sh"
+
+    # Use inreplace only if macOS AND the optional gnu-getopt was built
+    if OS.mac? && build.with?("gnu-getopt")
+      # Replace the simple `getopt` call with the full path to Homebrew's gnu-getopt
+      inreplace bin/"sshkeymanager.sh", "getopt", Formula["gnu-getopt"].opt_bin/"getopt"
+    end
   end
 
   def caveats
-    <<~EOS
+    s = <<~EOS
       The main utility `sshkeymanager.sh` has been installed to:
         #{opt_bin}/sshkeymanager.sh
 
@@ -37,6 +45,17 @@ class Sshkeymanager < Formula
 
       Restart your shell or source your profile for changes to take effect.
     EOS
+
+    if OS.mac?
+      s += <<~EOS
+
+        On macOS, it is recommended to install with gnu-getopt for full compatibility
+        with command-line options:
+          brew reinstall sshkeymanager --with-gnu-getopt
+      EOS
+    end
+
+    s # Return the combined caveats string
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -60,24 +60,31 @@ A comprehensive SSH key management tool that provides a menu-driven interface fo
 
 ## Usage
 
-### Command-Line Options
+The script can be run with various command-line options or using an interactive menu.
 
+```bash
+./sshkeymanager.sh [OPTIONS]
 ```
-sshkeymanager [OPTIONS]
 
-Options:
-  -l, --list          List keys currently loaded in the ssh-agent.
-  -a, --add           Finds potential private key files (with matching .pub)
-                      in the SSH directory, deletes all existing keys
-                      from the agent, then adds the found keys.
-  -f <file>, --file <file>
-                      Deletes all existing keys from the agent, then adds keys whose
-                      basenames are listed in the specified <file>.
-  -D, --delete-all    Delete all keys currently loaded in the ssh-agent.
-  -m, --menu          Show the interactive text-based menu interface.
-  -v, --verbose       Enable verbose (DEBUG level) logging.
-  -h, --help          Display help message and exit.
+**Options:**
+
+*   `-l`, `--list`: List keys currently loaded in the ssh-agent.
+*   `-a`, `--add`: Find potential keys, clear agent, add found keys.
+*   `-f <file>`, `--file <file>`: Load keys listed in `<file>` after clearing agent.
+*   `-D`, `--delete-all`: Delete all keys from agent (prompts for confirmation).
+*   `-m`, `--menu`: Show the interactive text-based menu interface.
+*   `-v`, `--verbose`: Enable verbose (DEBUG level) logging.
+*   `-h`, `--help`: Display the help message.
+
+**macOS Argument Parsing Note:**
+
+While the script functions on macOS without extra dependencies, installing `gnu-getopt` is recommended for the best command-line experience:
+
+```bash
+brew install gnu-getopt
 ```
+
+This enables support for features like combined short options (e.g., `-lv`) and long options (e.g., `--list`) which the default macOS `getopt` does not handle. If `gnu-getopt` is not installed, the script will fall back to a simpler parser, and only single short options (e.g., `-l -v`) will work.
 
 ### Interactive Menu Mode (`sshkeymanager -m`)
 

--- a/sshkeymanager.sh
+++ b/sshkeymanager.sh
@@ -1922,7 +1922,10 @@ _script_exit_handler() {
 #             run_interactive_menu. External commands: mktemp, printf.
 # ---
 main() {
-    # --- Setup Logging FIRST --- 
+    local parse_error=0 # Initialize parse_error to handle unbound variable with set -u
+    local FIRST_ACTION_SET=0 # Initialize flag for simple parser action tracking
+
+    # --- Setup Logging FIRST ---
     if ! setup_logging; then
         printf "Warning: Logging setup failed. Continuing with logging disabled.\n" >&2
     fi
@@ -1976,7 +1979,8 @@ main() {
     else
         # --- Use Simple Parsing Fallback --- (GNU getopt not found or check failed)
         # _check_gnu_getopt already logged the error
-        printf "Warning: GNU getopt not found or incompatible. Using simple parser.\n         Combined/long options unsupported. Install GNU getopt (e.g., 'brew install gnu-getopt' on macOS).\n" >&2
+        # Log this as info, as fallback works but lacks features. Avoids user-facing warning.
+        log_info "GNU getopt not found or incompatible. Using simple parser. Combined/long options unsupported. Recommendation: Install GNU getopt (e.g., 'brew install gnu-getopt' on macOS) for full argument support."
 
         local args_copy=("$@")
         local i=0


### PR DESCRIPTION
1. Fixed an issue where an error or warning was shown on invocation of the sshkeymanager on the console. This is now logged to the default location.
2. Update the README to recommend installing gnu-getopt for smooth argument parsing.
3. brew formula file updated to show gnu-getopt as an optional dependency.